### PR TITLE
Fix missing git hooks breaking fresh-machine install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 *.swp
+
+# Ensure the tracked git hooks are never dropped by a global core.excludesFile.
+!git-hooks/
+!git-hooks/**

--- a/git-hooks/post-checkout
+++ b/git-hooks/post-checkout
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-checkout' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-checkout "$@"

--- a/git-hooks/post-commit
+++ b/git-hooks/post-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-commit' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-commit "$@"

--- a/git-hooks/post-merge
+++ b/git-hooks/post-merge
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'post-merge' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs post-merge "$@"

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -15,8 +15,9 @@ set -e
 # If pre-commit isn't installed, do nothing rather than blocking the commit.
 command -v pre-commit >/dev/null 2>&1 || exit 0
 
-# 1. Global hooks (gitleaks + terraform + json + whitespace).
-pre-commit run --config "$HOME/.pre-commit-config.yaml" --hook-stage pre-commit
+# 1. Global hooks (gitleaks + terraform + json + whitespace), if a global config exists.
+[ -f "$HOME/.pre-commit-config.yaml" ] \
+  && pre-commit run --config "$HOME/.pre-commit-config.yaml" --hook-stage pre-commit
 
 # 2. Per-repo hooks if the current repo has its own config.
 [ -f .pre-commit-config.yaml ] && pre-commit run --hook-stage pre-commit

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Global pre-commit hook (installed via core.hooksPath).
+# Fires on every commit in every repo on this machine.
+#
+#   1. Runs the global hooks defined in ~/.pre-commit-config.yaml
+#      (gitleaks + the standard hook set).
+#   2. If the current repo also has its own .pre-commit-config.yaml,
+#      runs that too.
+#
+# Bypass for a single commit: `git commit --no-verify ...`
+# Disable for a single repo: `git config --local core.hooksPath ''`
+
+set -e
+
+# If pre-commit isn't installed, do nothing rather than blocking the commit.
+command -v pre-commit >/dev/null 2>&1 || exit 0
+
+# 1. Global hooks (gitleaks + terraform + json + whitespace).
+pre-commit run --config "$HOME/.pre-commit-config.yaml" --hook-stage pre-commit
+
+# 2. Per-repo hooks if the current repo has its own config.
+[ -f .pre-commit-config.yaml ] && pre-commit run --hook-stage pre-commit
+
+exit 0

--- a/git-hooks/pre-push
+++ b/git-hooks/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+command -v git-lfs >/dev/null 2>&1 || { printf >&2 "\n%s\n\n" "This repository is configured for Git LFS but 'git-lfs' was not found on your path. If you no longer wish to use Git LFS, remove this hook by deleting the 'pre-push' file in the hooks directory (set by 'core.hookspath'; usually '.git/hooks')."; exit 2; }
+git lfs pre-push "$@"

--- a/scripts/20-dotfiles.sh
+++ b/scripts/20-dotfiles.sh
@@ -43,6 +43,12 @@ done < <(find "${DOTFILES_DIR}" -type f -print0)
 
 # backup_then_symlink already handles directories and derives the backup
 # basename, so the same helper used for individual dotfiles applies here.
-backup_then_symlink "${ROOT}/git-hooks" "${HOME}/.git-hooks"
+# Guard against a fresh clone where git-hooks/ was never committed (or was
+# dropped by a global core.excludesFile) so the bootstrap does not abort.
+if [ -d "${ROOT}/git-hooks" ]; then
+  backup_then_symlink "${ROOT}/git-hooks" "${HOME}/.git-hooks"
+else
+  warn "git-hooks/ not found in the repository — skipping git hooks symlink."
+fi
 
 info "20-dotfiles: done."


### PR DESCRIPTION
## Summary

Running the installer on a fresh Mac failed with "source does not exist, cannot symlink: …/git-hooks". The repository's git hook files had never actually been committed — a global ignore rule silently excluded them — so a fresh clone had no hooks for the installer to link. Investigating this also surfaced a related hook that would block every commit on a newly provisioned machine.

## Changes

- Adds the previously-missing git hook files to the repository so the installer can link them on a fresh machine.
- Prevents a global ignore rule from silently dropping those hook files again.
- Makes the installer warn and continue, rather than abort, if the hooks are ever genuinely absent.
- Stops the global pre-commit hook from blocking commits on a machine that has no global pre-commit configuration.