### PR TITLE
Fix Homebrew tools not found by setup scripts on a fresh Mac

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -62,6 +62,31 @@ command_exists() {
 }
 
 # ---------------------------------------------------------------------------
+# Homebrew PATH bootstrap
+# ---------------------------------------------------------------------------
+
+# Ensure Homebrew and its installed tools (pyenv, tmux, node, ...) are on PATH.
+# install.sh runs each numbered script as a separate process, so the shellenv
+# set in 00-brew.sh does not propagate to siblings; re-establish it here so
+# every script can find brew-installed binaries. Read-only PATH setup, so it
+# runs in dry-run too (needed for accurate previews on a machine that has brew).
+ensure_brew_on_path() {
+  if command_exists brew; then
+    return 0
+  fi
+  if [ -x /opt/homebrew/bin/brew ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [ -x /usr/local/bin/brew ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
+  fi
+  # Explicit success: this function is called as a bare statement under set -e,
+  # so make the exit status immune to any future trailing-line edit.
+  return 0
+}
+
+ensure_brew_on_path
+
+# ---------------------------------------------------------------------------
 # Repository root resolution
 # ---------------------------------------------------------------------------
 

--- a/scripts/00-brew.sh
+++ b/scripts/00-brew.sh
@@ -45,17 +45,11 @@ else
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
-# Ensure brew is on PATH for the rest of this session, regardless of arch.
-# Apple Silicon installs to /opt/homebrew; Intel installs to /usr/local.
-# Only attempt this when brew actually exists on disk -- in dry-run on a
-# machine without Homebrew there is nothing to eval.
-if ! command_exists brew; then
-  if [[ -x /opt/homebrew/bin/brew ]]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-  elif [[ -x /usr/local/bin/brew ]]; then
-    eval "$(/usr/local/bin/brew shellenv)"
-  fi
-fi
+# Ensure brew is on PATH for the rest of this session.  common.sh already
+# calls ensure_brew_on_path() at source time, but if Homebrew was just
+# installed in the block above it was not yet on disk when common.sh ran.
+# Calling it again here picks up a freshly installed brew within this process.
+ensure_brew_on_path
 
 # Fail fast if brew still cannot be resolved -- every step below depends on it.
 # In dry-run mode on a machine without brew we cannot proceed further, but we

--- a/scripts/50-python.sh
+++ b/scripts/50-python.sh
@@ -27,7 +27,11 @@ PYTHON_VERSION="3.9.6"
 # ---------------------------------------------------------------------------
 
 if ! command_exists pyenv; then
-  err "pyenv not found. Ensure 00-brew.sh ran successfully."
+  if [[ "${DRY_RUN}" == "1" ]]; then
+    info "[dry-run] pyenv is not installed yet (00-brew would install it); skipping Python setup preview."
+    exit 0
+  fi
+  err "pyenv not found. Ensure 00-brew.sh ran and its packages are on PATH."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

On a fresh Mac the installer failed with "pyenv not found". Each setup step runs as a separate process, so the Homebrew environment established in the package-install step never reached the later steps — leaving Homebrew-installed tools (such as pyenv) off the PATH for the scripts that need them. Previewing the install with the dry-run flag hit the same step and stopped with an error instead of simply skipping it.

## Changes

- Makes every setup step put Homebrew (and the tools it installs, e.g. pyenv, tmux, node) on the PATH, so steps that depend on those tools find them regardless of run order.
- Lets the Python setup step skip cleanly during a dry run instead of failing when nothing has been installed yet, and gives a clearer message if the tools are genuinely missing on a real run.
- Removes duplicated PATH-setup logic from the package-install step by reusing the shared helper.