### PR TITLE
Make brew install idempotent, apps opt-in, and trim packages

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -27,6 +27,10 @@
 #   iterm2           — replaced by ghostty
 #   wezterm@nightly  — not in regular use
 
+# Adopt an app already present on disk instead of reinstalling it. Must sit
+# before the first `# group:` marker so the group parser ignores it.
+cask_args adopt: true
+
 # group: core
 # Always recommended: shell, git essentials, and the prompt font. The font is
 # kept here because the Ghostty/powerlevel10k prompt glyphs need it regardless
@@ -65,15 +69,12 @@ brew "stern"
 brew "terraform-docs"
 brew "terragrunt"
 brew "tfenv"
-brew "tflint"
 brew "tfsort"
 brew "trivy"
 
 # group: languages
 brew "ipython"
 brew "node"
-brew "openjdk@11"
-brew "openssl@1.1"
 brew "pipenv"
 brew "pyenv"
 brew "python@3.10"
@@ -86,7 +87,6 @@ brew "postgresql@17"
 # group: apps
 cask "adobe-acrobat-reader"
 cask "docker"
-cask "dropbox"
 cask "firefox"
 cask "flux"
 cask "ghostty"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ chmod +x install.sh scripts/*.sh
 The run prints a coloured `[INFO] / [WARN] / [ERROR]` log to stderr and a
 summary with next steps when it completes.
 
+### Installing the GUI apps
+
+The `apps` group (GUI casks) is **opt-in** and skipped by default in every
+mode. Pass `--with-apps` (or set `INSTALL_APPS=1`) to include it:
+
+```sh
+# Flag form
+./install.sh --with-apps
+
+# Environment form
+INSTALL_APPS=1 ./install.sh
+```
+
+You can also name `apps` explicitly in `BREW_GROUPS` (see below).
+
 ### Previewing changes (dry run)
 
 Run with `--dry-run` (or `-n`, or set `DRY_RUN=1` in the environment) to
@@ -115,16 +130,21 @@ assembles a temporary Brewfile from only the selected groups before calling
 | Group | Default | Roughly contains |
 |---|---|---|
 | `core` | **yes** | Shell and git essentials, plus the prompt font: `zsh`, `bash-completion`, `git-lfs`, `gh`, `tmux`, `bat`, `coreutils`, `gawk`, `jq`, `tree`, `wget`, `pre-commit`, and the `font-meslo-lg-nerd-font` cask. |
-| `cloud-devops` | no | Cloud and container tooling: `awscli`, `azure-cli`, `ansible`, `docker`/`docker-compose`, `colima`, `helm`, `minikube`, `k9s`, `stern`, `argocd`, and Terraform tooling (`tfenv`, `terragrunt`, `tflint`, `tfsort`, `terraform-docs`, `checkov`, `infracost`, `trivy`, `actionlint`). |
-| `languages` | no | Runtimes and toolchains: `node`, `python@3.10`, `pyenv`, `pipenv`, `uv`, `ipython`, `openjdk@11`, `openssl@1.1`. |
+| `cloud-devops` | no | Cloud and container tooling: `awscli`, `azure-cli`, `ansible`, `docker`/`docker-compose`, `colima`, `helm`, `minikube`, `k9s`, `stern`, `argocd`, and Terraform tooling (`tfenv`, `terragrunt`, `tfsort`, `terraform-docs`, `checkov`, `infracost`, `trivy`, `actionlint`). |
+| `languages` | no | Runtimes and toolchains: `node`, `python@3.10`, `pyenv`, `pipenv`, `uv`, `ipython`. |
 | `databases` | no | `mysql`, `postgresql@17`. |
-| `apps` | no | GUI casks: `ghostty`, `visual-studio-code`, `google-chrome`, `firefox`, `docker`, `dropbox`, `flux`, `adobe-acrobat-reader`. |
+| `apps` | no — opt-in via `--with-apps` | GUI casks: `ghostty`, `visual-studio-code`, `google-chrome`, `firefox`, `docker`, `flux`, `adobe-acrobat-reader`. |
 
 ### Choosing groups
 
 **Interactive (a terminal on stdin):** you are prompted per group. `core`
 defaults to yes (`[Y/n]`); every other group defaults to no (`[y/N]`), so a
 fresh machine installs only what you pick.
+
+The `apps` group is excluded from the defaults in **all** modes (interactive
+prompts, the non-interactive fallback, and dry-run) and is never prompted for.
+It is installed only via `--with-apps`, `INSTALL_APPS=1`, or by naming `apps`
+explicitly in `BREW_GROUPS`.
 
 **`BREW_GROUPS` override** (space- or comma-separated) pre-selects groups and
 skips the prompts on both interactive and non-interactive runs:
@@ -141,12 +161,15 @@ Behaviour summary:
 
 | Situation | Result |
 |---|---|
-| `BREW_GROUPS` set | Installs exactly those groups (prompts skipped). |
-| Interactive, `BREW_GROUPS` unset | Prompts per group (`core` defaults yes, rest no). |
-| Non-interactive, `BREW_GROUPS` unset (CI, piped input) | Installs **all** groups, with a warning, so unattended provisioning still works. |
+| `BREW_GROUPS` set | Installs exactly those groups (prompts skipped); may include `apps`. |
+| Interactive, `BREW_GROUPS` unset | Prompts per default group (`core` defaults yes, rest no); `apps` is not prompted. |
+| Non-interactive, `BREW_GROUPS` unset (CI, piped input) | Installs the default groups (everything except `apps`), with a warning, so unattended provisioning still works. |
+| `--with-apps` / `INSTALL_APPS=1` | Adds `apps` to the selection on any path above. |
 | Unknown group name | Rejected with an error listing the valid groups. |
 
 `brew bundle` is idempotent: re-running only installs whatever is missing.
+Already-installed packages are skipped (`--no-upgrade`), and apps already
+present on disk are adopted rather than reinstalled (`cask_args adopt: true`).
 
 > **Caveat on refreshing the Brewfile.** `brew bundle dump` does **not**
 > preserve the `# group:` markers. After a dump you must re-add the markers and
@@ -168,7 +191,7 @@ idempotent.
 | `25-git-identity.sh` | Sets the per-machine git identity. Prompts for name/email (or reads `GIT_USER_NAME`/`GIT_USER_EMAIL`, or skips on a non-TTY) and writes them to the untracked `~/.gitconfig.local`. |
 | `30-vim.sh` | Clones Vundle if absent, then runs `vim -u ~/.vimrc +PluginInstall +qall` to install the plugins declared in `.vimrc`. |
 | `40-tmux.sh` | Clones TPM if absent, then runs `tpm/bin/install_plugins` to install the plugins declared in `.tmux.conf`. |
-| `50-python.sh` | Installs the pinned Python version (`3.9.6`) via pyenv and sets it as the global default, then installs `flake8`, `ipython`, and `pytest` into that version's pip. |
+| `50-python.sh` | Installs the pinned Python version (`3.13.11`) via pyenv and sets it as the global default, then installs `flake8`, `ipython`, and `pytest` into that version's pip. |
 | `60-fonts.sh` | Installs fonts not available as Homebrew casks: FiraCode and Powerline fonts into `~/Library/Fonts`. Clones the Operator Mono ligature builder and builds it only if you supply the original OTF files in `.fonts-work/operator-mono-lig/original/`. |
 | `70-ssh.sh` | Generates an Ed25519 GitHub SSH key at `~/.ssh/id_ed25519_github`, adds it to the agent/keychain, appends a `github.com` host block to `~/.ssh/config`, and prints the public key. Skipped entirely if the key already exists. |
 | `80-macos.sh` | Applies a curated set of reversible `defaults write` system settings, then restarts Finder/Dock/SystemUIServer. |
@@ -186,7 +209,7 @@ Every file below is symlinked from `dotfiles/` into `$HOME`.
 
 | Dotfile | Manages |
 |---|---|
-| `.zshrc` | oh-my-zsh with the powerlevel10k theme and plugins (`git`, `autopep8`, `pep8`, `aws`, `tmux`, `zsh-syntax-highlighting`, `zsh-autosuggestions`); pyenv init; NVM; arch-aware OpenSSL/MySQL/Java PATH entries; the `k=kubectl` alias; sources `~/.bash_additions`; the powerlevel10k instant-prompt block; and the `claude` tmux wrapper (see below). |
+| `.zshrc` | oh-my-zsh with the powerlevel10k theme and plugins (`git`, `autopep8`, `pep8`, `aws`, `tmux`, `zsh-syntax-highlighting`, `zsh-autosuggestions`); pyenv init; NVM; arch-aware MySQL client and system Java PATH entries; the `k=kubectl` alias; sources `~/.bash_additions`; the powerlevel10k instant-prompt block; and the `claude` tmux wrapper (see below). |
 | `.vimrc` | Vundle-managed plugins — NERDTree, `vim-flake8`, `vim-airline`, SimpylFold, and `copilot.vim` — plus indent/fold settings, `Ctrl-t` to toggle NERDTree, and flake8 on save for `*.py`. |
 | `.tmux.conf` | TPM plugins (`tpm`, `tmux-sensible`, `nord-tmux`, `tmux-resurrect`, `tmux-colors-solarized`, `tmux-sessionx`); top status bar; vi-style keys; pane navigation/splitting; large scrollback; status-line styling. |
 | `.bashrc` | Interactive bash setup: sources `~/.bash_additions`, pyenv init, Homebrew and kubectl completion, Rust/cargo env. |
@@ -286,7 +309,8 @@ of `scripts/50-python.sh`.
 `./install.sh` is safe to re-run at any time:
 
 - Homebrew install is skipped (already present); `brew bundle` installs only
-  what is missing.
+  what is missing — already-installed packages are skipped and apps already
+  present on disk are adopted rather than reinstalled.
 - oh-my-zsh, theme, plugin, Vundle, TPM, and font clones are skipped if their
   directories already exist.
 - Symlinks that already point to the right source are left alone.

--- a/dotfiles/.zshrc
+++ b/dotfiles/.zshrc
@@ -35,30 +35,13 @@ else
   BREW_PREFIX=""
 fi
 
-# OpenSSL (1.1 required by some Python packages and older tooling).
-# Guarded so dead paths are not added when the formula is absent.
-if [ -n "${BREW_PREFIX}" ] && [ -d "${BREW_PREFIX}/opt/openssl@1.1" ]; then
-  export PATH="${BREW_PREFIX}/opt/openssl@1.1/bin:$PATH"
-  export LDFLAGS="-L${BREW_PREFIX}/opt/openssl@1.1/lib"
-  export CPPFLAGS="-I${BREW_PREFIX}/opt/openssl@1.1/include"
-fi
-
-# OpenSSL (legacy path used by some tools).
-if [ -n "${BREW_PREFIX}" ] && [ -d "${BREW_PREFIX}/opt/openssl" ]; then
-  export PATH="${BREW_PREFIX}/opt/openssl/bin:$PATH"
-  export DYLD_LIBRARY_PATH="${BREW_PREFIX}/opt/openssl/lib:${DYLD_LIBRARY_PATH:-}"
-fi
-
 # MySQL client (for building Python/Ruby MySQL extensions).
 if [ -n "${BREW_PREFIX}" ] && [ -d "${BREW_PREFIX}/opt/mysql-client" ]; then
   export PATH="${BREW_PREFIX}/opt/mysql-client/bin:$PATH"
   export PKG_CONFIG_PATH="${BREW_PREFIX}/opt/mysql-client/lib/pkgconfig"
 fi
 
-# Java 11 (via Homebrew openjdk@11).
-if [ -n "${BREW_PREFIX}" ] && [ -d "${BREW_PREFIX}/opt/openjdk@11" ]; then
-  export PATH="${BREW_PREFIX}/opt/openjdk@11/bin:$PATH"
-fi
+# macOS system Java.
 export PATH="$PATH:/usr/bin/java"
 export JAVA_HOME=$(/usr/libexec/java_home 2>/dev/null || true)
 

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,11 @@
 # install.sh -- idempotent macOS bootstrap entrypoint.
 #
 # Usage:
-#   ./install.sh [--dry-run|-n] [--help|-h]
+#   ./install.sh [--with-apps] [--dry-run|-n] [--help|-h]
 #
 # Options:
+#   --with-apps     Also install the apps group (GUI casks). Skipped by default.
+#                   Also activated by setting INSTALL_APPS=1 in the environment.
 #   --dry-run, -n   Preview every action without making any change to the
 #                   system. Also activated by setting DRY_RUN=1 in the
 #                   environment before running.
@@ -13,7 +15,7 @@
 # Runs all numbered scripts under scripts/ in ascending numeric order.
 # Safe to re-run: every script is designed to be idempotent.
 #
-# DRY_RUN is exported so every child script inherits it automatically.
+# DRY_RUN and INSTALL_APPS are exported so every child script inherits them.
 
 set -euo pipefail
 
@@ -27,8 +29,10 @@ source "${SCRIPT_DIR}/lib/common.sh"
 # ---------------------------------------------------------------------------
 
 _print_usage() {
-  printf 'Usage: %s [--dry-run|-n] [--help|-h]\n\n' "$(basename "$0")"
+  printf 'Usage: %s [--with-apps] [--dry-run|-n] [--help|-h]\n\n' "$(basename "$0")"
   printf 'Options:\n'
+  printf '  --with-apps     Also install the apps group (GUI casks). Skipped by default.\n'
+  printf '                  Also activated by INSTALL_APPS=1 in the environment.\n'
   printf '  --dry-run, -n   Preview all actions without making any system change.\n'
   printf '                  Also activated by DRY_RUN=1 in the environment.\n'
   printf '  --help,    -h   Print this message and exit.\n'
@@ -36,6 +40,10 @@ _print_usage() {
 
 for _arg in "$@"; do
   case "${_arg}" in
+  --with-apps)
+    INSTALL_APPS=1
+    export INSTALL_APPS
+    ;;
   --dry-run | -n)
     DRY_RUN=1
     export DRY_RUN
@@ -56,6 +64,11 @@ unset _arg
 # lib/common.sh already defaulted DRY_RUN to 0 if unset; the flag above
 # may have overridden it to 1.  Either way, export so child scripts inherit.
 export DRY_RUN
+
+# apps is opt-in: default INSTALL_APPS to 0 when unset, then export so child
+# scripts inherit it even when the flag/env var was not provided.
+: "${INSTALL_APPS:=0}"
+export INSTALL_APPS
 
 # ---------------------------------------------------------------------------
 # Preflight checks

--- a/scripts/00-brew.sh
+++ b/scripts/00-brew.sh
@@ -6,15 +6,19 @@
 # everything:
 #
 #   * Interactive (a TTY on stdin): you are prompted per group. `core` defaults
-#     to yes; every other group defaults to no.
+#     to yes; every other default group defaults to no.
 #   * Non-interactive (no TTY): the BREW_GROUPS env var selects groups
-#     (space- or comma-separated). If BREW_GROUPS is unset, ALL groups are
-#     installed (so unattended/CI runs still work) with a warning.
+#     (space- or comma-separated). If BREW_GROUPS is unset, the default groups
+#     are installed (so unattended/CI runs still work) with a warning.
 #
 # BREW_GROUPS is also honoured on the interactive path: when set it pre-selects
 # those groups and skips the prompts. Unknown group names are rejected.
 #
 #   BREW_GROUPS="core languages" ./install.sh
+#
+# The `apps` group (GUI casks) is OPT-IN: it is excluded from the default
+# selection in every mode and is installed only when one of the following is
+# given: the --with-apps flag (INSTALL_APPS=1), or BREW_GROUPS naming `apps`.
 #
 # Dry-run mode (DRY_RUN=1):
 #   Homebrew installation is skipped with a log message.
@@ -29,8 +33,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/../lib/common.sh"
 
 # Known groups, in the order they are prompted / assembled. This is the single
-# source of truth for valid group names.
+# source of truth for valid group names. BREW_GROUPS validation accepts any of
+# these, including apps.
 KNOWN_GROUPS=(core cloud-devops languages databases apps)
+
+# Groups selected by default (interactive prompts and the unattended fallback).
+# apps is deliberately excluded -- it is opt-in only (see INSTALL_APPS below).
+DEFAULT_GROUPS=(core cloud-devops languages databases)
+
+# apps is opt-in. Default to 0 when unset so `set -u` references are safe.
+: "${INSTALL_APPS:=0}"
 
 # ---------------------------------------------------------------------------
 # Install Homebrew
@@ -219,16 +231,16 @@ if [[ -n "${BREW_GROUPS:-}" ]]; then
   validate_groups "${SELECTED_GROUPS[@]}"
   info "Using groups from BREW_GROUPS: ${SELECTED_GROUPS[*]}"
 elif [[ ! -t 0 ]]; then
-  # Non-interactive and no explicit selection -> install everything so that
-  # unattended/CI runs still provision a full machine.
-  warn "Non-interactive shell and BREW_GROUPS unset -- installing ALL groups."
-  warn "Set BREW_GROUPS (e.g. 'core languages') to install a subset unattended."
-  SELECTED_GROUPS=("${KNOWN_GROUPS[@]}")
+  # Non-interactive and no explicit selection -> install the default groups so
+  # that unattended/CI runs still provision a machine. apps is excluded.
+  warn "Non-interactive shell and BREW_GROUPS unset -- installing default groups."
+  warn "Pass --with-apps to include GUI apps, or set BREW_GROUPS (e.g. 'core languages')."
+  SELECTED_GROUPS=("${DEFAULT_GROUPS[@]}")
 else
   # Interactive: show each group's contents, then prompt. core defaults to yes;
-  # the rest default to no.
+  # the rest default to no. apps is not prompted -- it is opt-in via --with-apps.
   info "Choose which Homebrew groups to install."
-  for group in "${KNOWN_GROUPS[@]}"; do
+  for group in "${DEFAULT_GROUPS[@]}"; do
     count="$(count_group_entries "${group}")"
     printf '\nGroup '\''%s'\'' (%s packages):\n' "${group}" "${count}"
     list_group_entries "${group}"
@@ -246,6 +258,23 @@ else
   done
 fi
 
+# --with-apps (INSTALL_APPS=1) guarantees the GUI apps group is included,
+# regardless of how the other groups were selected. apps is never installed
+# automatically otherwise.
+if [[ "${INSTALL_APPS}" == "1" ]]; then
+  if [[ "${#SELECTED_GROUPS[@]}" -eq 0 ]] ||
+    ! printf '%s\n' "${SELECTED_GROUPS[@]}" | grep -qxF apps; then
+    SELECTED_GROUPS+=(apps)
+  fi
+  info "Including 'apps' group (GUI casks) via --with-apps."
+fi
+
+# Tell the user how to get apps if it was not selected on any path.
+if [[ "${#SELECTED_GROUPS[@]}" -eq 0 ]] ||
+  ! printf '%s\n' "${SELECTED_GROUPS[@]}" | grep -qxF apps; then
+  info "Skipping 'apps' group (GUI casks) -- pass --with-apps or BREW_GROUPS=...,apps to install it."
+fi
+
 if [[ "${#SELECTED_GROUPS[@]}" -eq 0 ]]; then
   warn "No groups selected -- skipping brew bundle."
 fi
@@ -259,9 +288,16 @@ if [[ "${#SELECTED_GROUPS[@]}" -gt 0 ]]; then
   # Ensure the temp file is removed on any exit path.
   trap 'rm -f "${TMP_BREWFILE}"' EXIT
 
-  assemble_brewfile "${SELECTED_GROUPS[@]}" >"${TMP_BREWFILE}"
+  # Prepend `cask_args adopt: true` so an app already present on disk (e.g.
+  # installed outside Homebrew) is adopted rather than reinstalled. Combined
+  # with --no-upgrade this stops re-runs from touching apps you already have.
+  {
+    printf 'cask_args adopt: true\n'
+    assemble_brewfile "${SELECTED_GROUPS[@]}"
+  } >"${TMP_BREWFILE}"
 
-  total="$(wc -l <"${TMP_BREWFILE}" | tr -d ' ')"
+  # Count only install entries; the cask_args directive is not a package.
+  total="$(grep -cE '^(tap|brew|cask) ' "${TMP_BREWFILE}" || true)"
 
   if [[ "${DRY_RUN}" == "1" ]]; then
     info "[dry-run] assembled Brewfile for groups: ${SELECTED_GROUPS[*]} (${total} lines)"
@@ -270,10 +306,13 @@ if [[ "${#SELECTED_GROUPS[@]}" -gt 0 ]]; then
     while IFS= read -r line; do
       info "  ${line}"
     done <"${TMP_BREWFILE}"
-    info "[dry-run] would run: brew bundle --file=${TMP_BREWFILE}"
+    info "[dry-run] would run: brew bundle install --no-upgrade --file=${TMP_BREWFILE}"
   else
     info "Installing ${total} packages across groups: ${SELECTED_GROUPS[*]}"
-    brew bundle --file="${TMP_BREWFILE}"
+    # brew bundle upgrades by default, which reinstalls already-installed packages
+    # (notably auto_updates casks like adobe-acrobat-reader) on every run.
+    # --no-upgrade makes re-runs install only what's missing, keeping runs idempotent.
+    brew bundle install --no-upgrade --file="${TMP_BREWFILE}"
   fi
 fi
 

--- a/scripts/50-python.sh
+++ b/scripts/50-python.sh
@@ -15,12 +15,12 @@ source "${SCRIPT_DIR}/../lib/common.sh"
 # The Python version to pin.  Change here to update the whole machine.
 #
 # NOTE: `pyenv install` compiles CPython from source and therefore needs the
-# build dependencies present (openssl, readline, xz, zlib, etc.). These come
-# from the Brewfile (openssl@1.1) plus the Xcode Command Line Tools. Building
-# an older release such as 3.9.6 can fail on a modern toolchain (newer clang
-# or OpenSSL 3.x). If `pyenv install` fails on a fresh machine, bump this
-# pinned version to a release that builds cleanly on the current toolchain.
-PYTHON_VERSION="3.9.6"
+# build dependencies present (openssl, readline, xz, zlib, etc.) plus the Xcode
+# Command Line Tools. A modern Python builds cleanly against the OpenSSL that
+# Homebrew pulls in as a dependency (openssl@3). If `pyenv install` fails on a
+# fresh machine, bump this pinned version to a release that builds cleanly on
+# the current toolchain.
+PYTHON_VERSION="3.13.11"
 
 # ---------------------------------------------------------------------------
 # Ensure pyenv is available


### PR DESCRIPTION
## Summary

Re-running the installer reinstalled applications that were already present (Adobe Acrobat Reader was the obvious one), and the GUI applications were installed automatically even when they weren't wanted. This makes re-runs skip anything already installed, makes the GUI applications optional, and trims a few packages that are no longer needed.

## Changes

- Re-running now skips packages that are already installed instead of reinstalling or upgrading them; applications already present on the machine are kept rather than reinstalled.
- The GUI applications group is no longer installed by default — pass `--with-apps` (or set `INSTALL_APPS=1`) to include it.
- Removed Dropbox, the end-of-life OpenSSL 1.1 and OpenJDK 11 packages, and the TFLint linter from the package list, together with their now-unused shell PATH settings.
- Updated the pinned Python version to a current release so it builds cleanly on a fresh machine without the removed OpenSSL 1.1.
- Updated the documentation to match.