### PR TITLE
Document re-running p10k configure to change prompt style

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,33 @@ A few things complete on first use rather than during the bootstrap:
 - **powerlevel10k prompt.** On the first interactive shell, if `~/.p10k.zsh` is
   absent, powerlevel10k runs its `p10k configure` wizard automatically. The
   required `MesloLGS NF` font is installed by the `core` Brewfile group.
+  Re-run the interactive wizard at any time to change the prompt style:
+  ```sh
+  p10k configure
+  ```
+  It is non-destructive — it rewrites `~/.p10k.zsh` with your choices and
+  reloads the prompt. The wizard's first questions detect your terminal font,
+  so the terminal must already be using the `MesloLGS NF` Nerd Font (Ghostty's
+  bundled config sets this; other terminals must set it manually) or the
+  preview glyphs render as missing-glyph boxes. The wizard asks a series of
+  questions; the key answers that produce the one-line **Rainbow** prompt
+  (filled coloured powerline segments) are:
+
+  | Question | Answer |
+  |---|---|
+  | Prompt Style | Rainbow |
+  | Show current time | 24-hour |
+  | Prompt Separators | Angled |
+  | Prompt Heads | Sharp |
+  | Prompt Tails | Flat |
+  | Prompt Height | One line |
+  | Prompt Spacing | Compact |
+  | Icons | Many |
+  | Prompt Flow | Concise |
+
+  then apply/save when prompted. `p10k configure` only affects the machine it
+  is run on; a fresh install elsewhere falls back to the wizard unless
+  `~/.p10k.zsh` is committed into `dotfiles/`.
 - **Vim plugins.** Installed by `30-vim.sh`. To install plugins added to
   `.vimrc` later, or to re-run by hand:
   ```sh


### PR DESCRIPTION
## Summary

A fresh Mac drops you into the powerlevel10k setup wizard on first shell, but the README never explained how to change the prompt style afterwards. This documents how to re-run the wizard at any time and which answers reproduce the project's one-line Rainbow prompt.

## Changes

- Extend the powerlevel10k entry under "First-run / post-install steps" to cover re-running `p10k configure` on demand, noting it is non-destructive and machine-local.
- Add the key wizard answers that reproduce the one-line Rainbow prompt.
- Note that the terminal must use the MesloLGS NF Nerd Font for the wizard previews to render, and that committing `~/.p10k.zsh` into `dotfiles/` is what propagates the look to other machines.